### PR TITLE
Fix file handle type for x64 in Tools.cpp

### DIFF
--- a/FinalAssignment_/Tools.cpp
+++ b/FinalAssignment_/Tools.cpp
@@ -67,7 +67,7 @@ std::vector<std::string> Tools::GetFileNameInFolder(std::string folderPath)
 void Tools::GetFileNameInFolder(std::string folderPath, std::vector<std::string>& dest)
 {
 	//文件句柄  
-	long   hFile = 0;
+	intptr_t   hFile = 0;
 	//文件信息  
 	struct _finddata_t fileinfo;
 	std::string p;


### PR DESCRIPTION
The file handle type is 32-bit in x86, while it is 64-bit in x64.
Replace 'long' with the platform independent type 'intptr_t'.